### PR TITLE
Adapt scripts for Odoo 18 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
-﻿# MyXMLRPCOdooIOScript
+# MyXMLRPCOdooIOScript
 
-Ce projet regroupe deux scripts Python qui exportent et importent des taches Odoo via l'API XML-RPC. Une classe `Project` centralise le chargement de la configuration, l'authentification et les appels partages.
+Ce projet regroupe deux scripts Python qui exportent et importent des taches Odoo via l'API XML-RPC. Une classe `Project` centralise le chargement de la configuration, l'authentification, les appels partages et controle que l'instance visee execute Odoo 18.x ou plus recent.
+
+## Compatibilite Odoo 18
+- Verification de version : un appel `common.version()` est realise lors de l'initialisation et l'execution est interrompue si le serveur est en dessous de la version 18.
+- Alias de champs : les scripts gèrent automatiquement les renommages introduits en V18 (`planned_date_begin` -> `date_planned_start`, `planned_hours` -> `allocated_hours`, etc.) afin que les exports et imports restent fonctionnels meme si vos fichiers utilisent les anciennes appellations.
+- Metadonnees d'export : les fichiers generes contiennent la serie et la version du serveur ainsi que les correspondances de champs appliquees, ce qui facilite les verifications et audits.
 
 ## Diagramme des classes
 ```mermaid
@@ -13,18 +18,26 @@ classDiagram
         +models
         +common
         +uid: int
+        +server_serie: str
+        +server_version_info: tuple
         +Project(env_path=".env", defaults)
         +fields_available(model)
         +search_read(model, domain, fields, limit="0")
         +export_tasks(project_filter, task_field_candidates, json_path, csv_path)
         +import_tasks(updates_path, allowed_fields)
         -_load_env(path)
+        -_map_field_name(model, field, available_fields)
+        -_resolve_fields(model, candidates, available_fields)
     }
 ```
 
+## Champs proposes
+- **Export** : par defaut `export_project.py` demande les principaux champs V18 des taches (ex. `task_type_id`, `milestone_id`, `allocated_hours`, `date_planned_start`, ...). Les champs absents sont ignores automatiquement.
+- **Import** : `import project.py` autorise la mise a jour des champs de planification (anciennes et nouvelles denominations), de la priorite, de la facturation (`allow_billable`) et des jalons (`milestone_id`). Ajustez les constantes `TASK_FIELD_CANDIDATES` et `ALLOWED_FIELDS` selon vos besoins.
+
 ## Prerequis
-- Python 3.9 ou plus recent (les modules utilises font partie de la bibliotheque standard)
-- Acces a un serveur Odoo via XML-RPC
+- Python 3.9 ou plus recent (les modules utilises font partie de la bibliotheque standard).
+- Acces a un serveur Odoo 18.x via XML-RPC (`https://votre-instance.odoo.com/xmlrpc/2/`).
 
 ## Configuration
 1. Dupliquez `.env` (ou creez-le a partir du modele ci-dessous) et renseignez vos identifiants Odoo :
@@ -70,4 +83,5 @@ Le script affiche le nombre de taches mises a jour (`OK`) et celles en erreur (`
 
 ## Conseils
 - Ne committez pas votre fichier `.env` (il est deja ajoute a `.gitignore`).
-- Lancez d'abord l'export pour verifier la connexion a Odoo avant de proceder a l'import.
+- Lancez d'abord l'export pour verifier la connexion a Odoo et la correspondance des champs avant de proceder a l'import.
+- Consultez la section "Champs proposes" pour verifier que les identifiants utilises correspondent bien a votre configuration fonctionnelle.

--- a/export_project.py
+++ b/export_project.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import sys
@@ -7,11 +7,13 @@ from project import Project
 
 PROJECT_FILTER = {"type": "name", "value": "MyMemoMaster"}
 TASK_FIELD_CANDIDATES = [
-    'id', 'name', 'user_id', 'project_id', 'stage_id', 'priority', 'kanban_state',
-    'description', 'tag_ids',
+    'id', 'name', 'user_id', 'project_id', 'stage_id', 'task_type_id',
+    'priority', 'kanban_state', 'kanban_state_label',
+    'description', 'tag_ids', 'milestone_id', 'parent_id',
+    'allow_billable', 'is_closed',
     'date_deadline', 'date_assign', 'date_start', 'date_end',
-    'planned_hours', 'remaining_hours', 'progress',
-    'planned_date_begin', 'planned_date_end',
+    'planned_hours', 'allocated_hours', 'remaining_hours', 'progress',
+    'planned_date_begin', 'planned_date_end', 'date_planned_start', 'date_planned_end',
     'create_date', 'write_date',
 ]
 DEFAULTS = {

--- a/import project.py
+++ b/import project.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import sys
@@ -13,7 +13,9 @@ DEFAULTS = {
 }
 ALLOWED_FIELDS = {
     'description', 'date_deadline', 'planned_date_begin', 'planned_date_end',
-    'date_start', 'date_end', 'planned_hours', 'priority',
+    'date_planned_start', 'date_planned_end',
+    'date_start', 'date_end', 'planned_hours', 'allocated_hours', 'priority',
+    'allow_billable', 'milestone_id',
 }
 
 

--- a/project.py
+++ b/project.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import csv
@@ -6,12 +6,25 @@ import json
 import os
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
 
 from xmlrpc import client as xmlrpclib
 
+MINIMUM_SUPPORTED_MAJOR = 18
 
-class Project():
+FIELD_ALIASES: Dict[str, Dict[str, Tuple[str, ...]]] = {
+    'project.task': {
+        'planned_date_begin': ('date_planned_start',),
+        'planned_date_end': ('date_planned_end',),
+        'date_planned_start': ('planned_date_begin',),
+        'date_planned_end': ('planned_date_end',),
+        'allocated_hours': ('planned_hours',),
+        'planned_hours': ('allocated_hours',),
+    },
+}
+
+
+class Project:
     """Wrapper around the Odoo XML-RPC project API with shared helpers."""
 
     def __init__(self, env_path: str = ".env", defaults: Optional[Dict[str, str]] = None) -> None:
@@ -23,8 +36,23 @@ class Project():
         self.user = os.getenv("ODOO_USER", defaults.get("user", ""))
         self.password = os.getenv("ODOO_PASSWORD", defaults.get("password", ""))
 
-        self.models = xmlrpclib.ServerProxy(f"{self.url}/xmlrpc/2/object")
-        self.common = xmlrpclib.ServerProxy(f"{self.url}/xmlrpc/2/common")
+        self.models = xmlrpclib.ServerProxy(f"{self.url}/xmlrpc/2/object", allow_none=True)
+        self.common = xmlrpclib.ServerProxy(f"{self.url}/xmlrpc/2/common", allow_none=True)
+
+        version_data: Dict[str, Any] = self.common.version()
+        self.server_serie: str = version_data.get("server_serie", "")
+        server_version_info: Sequence[Any] = version_data.get("server_version_info") or ()
+        self.server_version_info: Tuple[Any, ...] = tuple(server_version_info)
+        try:
+            self.server_major_version = int(self.server_version_info[0])
+        except (ValueError, TypeError, IndexError):
+            self.server_major_version = 0
+        if self.server_major_version and self.server_major_version < MINIMUM_SUPPORTED_MAJOR:
+            raise RuntimeError(
+                f"Serveur Odoo non supporte: version {self.server_serie or self.server_version_info}. "
+                f"La compatibilite ciblee est Odoo {MINIMUM_SUPPORTED_MAJOR}.x ou plus recent."
+            )
+
         self.uid = self.common.authenticate(self.db, self.user, self.password, {})
         if not self.uid:
             raise RuntimeError("Authentication failed; please check Odoo credentials.")
@@ -59,6 +87,35 @@ class Project():
         )
         return list(fields.keys())
 
+    def _map_field_name(self, model: str, field: str, available_fields: Set[str]) -> Optional[str]:
+        if field in available_fields:
+            return field
+        model_aliases = FIELD_ALIASES.get(model, {})
+        for alias in model_aliases.get(field, ()): 
+            if alias in available_fields:
+                return alias
+        return None
+
+    def _resolve_fields(
+        self,
+        model: str,
+        candidates: Iterable[str],
+        available_fields: Optional[Set[str]] = None,
+    ) -> Tuple[List[str], Dict[str, str]]:
+        available_fields = available_fields or set(self.fields_available(model))
+        resolved: List[str] = []
+        alias_usage: Dict[str, str] = {}
+        seen: Set[str] = set()
+        for field in candidates:
+            mapped = self._map_field_name(model, field, available_fields)
+            if not mapped or mapped in seen:
+                continue
+            resolved.append(mapped)
+            seen.add(mapped)
+            if mapped != field:
+                alias_usage[field] = mapped
+        return resolved, alias_usage
+
     def search_read(
         self,
         model: str,
@@ -84,15 +141,18 @@ class Project():
         csv_path: str = 'tasks.csv',
     ) -> int:
         candidates = list(task_field_candidates or []) or [
-            'id', 'name', 'user_id', 'project_id', 'stage_id', 'priority', 'kanban_state',
-            'description', 'tag_ids',
+            'id', 'name', 'user_id', 'project_id', 'stage_id', 'task_type_id',
+            'priority', 'kanban_state', 'kanban_state_label',
+            'description', 'tag_ids', 'milestone_id', 'parent_id',
             'date_deadline', 'date_assign', 'date_start', 'date_end',
-            'planned_hours', 'remaining_hours', 'progress',
-            'planned_date_begin', 'planned_date_end',
+            'planned_hours', 'allocated_hours', 'remaining_hours', 'progress',
+            'planned_date_begin', 'planned_date_end', 'date_planned_start', 'date_planned_end',
             'create_date', 'write_date',
         ]
         available_fields = set(self.fields_available('project.task'))
-        task_fields = [field for field in candidates if field in available_fields]
+        task_fields, alias_usage = self._resolve_fields('project.task', candidates, available_fields)
+        if not task_fields:
+            raise RuntimeError("Aucun champ valide trouve pour l'export des taches.")
 
         proj_domain: List[Tuple[str, str, object]] = []
         if project_filter.get('type') == 'name':
@@ -116,6 +176,9 @@ class Project():
                 'exported_at': datetime.utcnow().isoformat() + 'Z',
                 'odoo_url': self.url,
                 'db': self.db,
+                'server_serie': self.server_serie,
+                'server_version_info': list(self.server_version_info),
+                'field_aliases': alias_usage,
                 'project_ids': project_ids,
                 'task_fields': task_fields,
             },
@@ -147,12 +210,14 @@ class Project():
         allowed_fields: Optional[Iterable[str]] = None,
     ) -> Tuple[int, int]:
         update_data = json.loads(Path(updates_path).read_text(encoding='utf-8'))
-        allowed = set(allowed_fields or [
+        allowed = list(allowed_fields or [
             'description', 'date_deadline', 'planned_date_begin', 'planned_date_end',
-            'date_start', 'date_end', 'planned_hours', 'priority',
+            'date_planned_start', 'date_planned_end',
+            'date_start', 'date_end', 'planned_hours', 'allocated_hours', 'priority',
         ])
         available_fields = set(self.fields_available('project.task'))
-        editable_fields = allowed.intersection(available_fields)
+        editable_fields, _ = self._resolve_fields('project.task', allowed, available_fields)
+        editable_fields_set = set(editable_fields)
 
         success, failure = 0, 0
         for item in update_data:
@@ -161,8 +226,11 @@ class Project():
                 failure += 1
                 continue
             values = {
-                key: value for key, value in item.items()
-                if key in editable_fields and value is not None
+                mapped_key: value
+                for key, value in item.items()
+                if key != 'id'
+                for mapped_key in [self._map_field_name('project.task', key, available_fields)]
+                if mapped_key and mapped_key in editable_fields_set and value is not None
             }
             if not values:
                 continue


### PR DESCRIPTION
## Summary
- validate that the XML-RPC connection targets an Odoo 18.x server and expose version metadata in exports
- add field alias resolution plus updated default task field lists to cover the new planning fields introduced in v18
- document the v18 compatibility requirements and configurable field sets in the README

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68ca5e7a5bc88331b920be7514f73bca